### PR TITLE
fix: install supported kernels for AWS and configure them

### DIFF
--- a/ansible/aws/aws_env_setup_centos_7.yaml
+++ b/ansible/aws/aws_env_setup_centos_7.yaml
@@ -5,7 +5,12 @@
   gather_facts: no
   force_handlers: True
   tasks:
-  - name: update packages
+  # - name: Add mirrors # Don't run normally but run manually if there is a mirror issue
+  #   shell: |
+  #     sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+  #     sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
+  - name: Update packages
     shell: yum update
 
   - name: Ensure unzip is installed
@@ -38,3 +43,24 @@
     copy:
       src: "~/.aws/config"
       dest: "~/.aws/config"
+      
+  - name: Remove current kernel boot files
+    shell: rm -f /boot/*
+    ignore_errors: yes
+
+  - block:
+    - name: Install AWS supported linux kernel # AWS image build is not stable on non-generic kernals.
+      apt:
+        name: kernel-3.10.0-1160.90.1*
+        state: present
+    rescue:
+    - name: Install the kernel via shell
+      shell: "yum install kernel-3.10.0-1160.90.1* -y"
+    tags:
+        - devel
+
+  - name: Configure new kernel boot files
+    shell: |
+      kernel=$(rpm -q kernel | grep 3.10.0-1160.90.1 | sed 's/kernel/\/boot\/vmlinuz/')
+      grubby --set-default $kernel
+      grub2-mkconfig -o /boot/grub2/grub.cfg

--- a/ansible/aws/aws_env_setup_centos_8.yaml
+++ b/ansible/aws/aws_env_setup_centos_8.yaml
@@ -5,7 +5,12 @@
   gather_facts: no
   force_handlers: True
   tasks:
-  - name: update packages
+  # - name: Add mirrors # Don't run normally but run manually if there is a mirror issue
+  #   shell: |
+  #     sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+  #     sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
+  - name: Update packages
     shell: yum update
 
   - name: Ensure unzip is installed
@@ -38,3 +43,24 @@
     copy:
       src: "~/.aws/config"
       dest: "~/.aws/config"
+      
+  - name: Remove current kernel boot files
+    shell: rm -f /boot/*
+    ignore_errors: yes
+
+  - block:
+    - name: Install AWS supported linux kernel # AWS image build is not stable on non-generic kernals.
+      apt:
+        name: kernel-4.18.0-348.2.1*
+        state: present
+    rescue:
+    - name: Install the kernel via shell
+      shell: "yum install kernel-4.18.0-348.2.1* -y"
+    tags:
+        - devel
+
+  - name: Configure new kernel boot files
+    shell: |
+      kernel=$(rpm -q kernel | grep 4.18.0-348.2.1 | sed 's/kernel/\/boot\/vmlinuz/')
+      grubby --set-default $kernel
+      grub2-mkconfig -o /boot/grub2/grub.cfg

--- a/ansible/aws/aws_env_setup_redhat_7.yaml
+++ b/ansible/aws/aws_env_setup_redhat_7.yaml
@@ -5,7 +5,7 @@
   gather_facts: no
   force_handlers: True
   tasks:
-  - name: update packages
+  - name: Update packages
     shell: yum update
 
   - name: Ensure unzip is installed
@@ -38,3 +38,24 @@
     copy:
       src: "~/.aws/config"
       dest: "~/.aws/config"
+
+  - name: Remove current kernel boot files
+    shell: rm -f /boot/*
+    ignore_errors: yes
+
+  - block:
+    - name: Install AWS supported linux kernel # AWS image build is not stable on non-generic kernals.
+      apt:
+        name: kernel-3.10.0-1160.90.1*
+        state: present
+    rescue:
+    - name: Install the kernel via shell
+      shell: "yum install kernel-3.10.0-1160.90.1* -y"
+    tags:
+        - devel
+
+  - name: Configure new kernel boot files
+    shell: |
+      kernel=$(rpm -q kernel | grep 3.10.0-1160.90.1 | sed 's/kernel/\/boot\/vmlinuz/')
+      grubby --set-default $kernel
+      grub2-mkconfig -o /boot/grub2/grub.cfg

--- a/ansible/aws/aws_env_setup_redhat_8.yaml
+++ b/ansible/aws/aws_env_setup_redhat_8.yaml
@@ -5,7 +5,7 @@
   gather_facts: no
   force_handlers: True
   tasks:
-  - name: update packages
+  - name: Update packages
     shell: yum update
 
   - name: Ensure unzip is installed
@@ -37,4 +37,25 @@
   - name: Configure aws region
     copy:
       src: "~/.aws/config"
-      dest: "~/.aws/config"
+      dest: "~/.aws/config"   
+  
+  - name: Remove current kernel boot files
+    shell: rm -f /boot/*
+    ignore_errors: yes
+
+  - block:
+    - name: Install AWS supported linux kernel # AWS image build is not stable on non-generic kernals.
+      apt:
+        name: kernel-4.18.0-147.8.1*
+        state: present
+    rescue:
+    - name: Install the kernel via shell
+      shell: "yum install kernel-4.18.0-147.8.1* -y"
+    tags:
+        - devel
+
+  - name: Configure new kernel boot files
+    shell: |
+      kernel=$(rpm -q kernel | grep 4.18.0-147.8.1 | sed 's/kernel/\/boot\/vmlinuz/')
+      grubby --set-default $kernel
+      grub2-mkconfig -o /boot/grub2/grub.cfg

--- a/ansible/aws/aws_env_setup_ubuntu_16.yaml
+++ b/ansible/aws/aws_env_setup_ubuntu_16.yaml
@@ -6,7 +6,7 @@
   gather_facts: no
   force_handlers: True
   tasks:
-  - name: update packages
+  - name: Update packages
     shell: apt update
     
   - name: Ensure unzip is installed
@@ -24,7 +24,11 @@
   - name: Remove all kernels other than the active kernel # This might install unsigned versions of some kernels
     shell: |
       kernel=$(uname -r)
-      dpkg -l | grep -i 'linux-image\|linux-headers' | grep -v $kernel | awk '{print $2}' | xargs apt purge --auto-remove -y
+      dpkg -l | grep 'linux-image\|linux-headers' | grep -v $kernel | awk '{print $2}' | xargs apt purge --auto-remove -y
+    ignore_errors: yes
+
+  - name: Remove active kernel boot files
+    shell: rm -f /boot/*
     ignore_errors: yes
 
   - block:
@@ -40,12 +44,8 @@
     
   - name: Configure new kernel boot files
     shell: |
-      kernel=$(dpkg -l | grep -E linux-image-4.*-generic | awk '{print $2}' | sed 's/linux-image-//')
-      update-initramfs -u -k $kernel
-
-  - name: Remove AWS kernel boot files
-    shell: cd /boot && rm -f *aws
-   
+      kernel=$(dpkg -l | grep -E 'linux\-image\-4\.(2|4|8|10|15).*\-generic' | awk '{print $2}' | sed 's/linux-image-//')
+      update-initramfs -u -k $kernel 
 
   - name: Remove EFI entries
     shell: mv /boot/efi/boot/grub/grub.cfg /boot/efi/boot/grub/grub.cfg.bak

--- a/ansible/aws/aws_env_setup_ubuntu_18.04.yaml
+++ b/ansible/aws/aws_env_setup_ubuntu_18.04.yaml
@@ -6,7 +6,7 @@
   gather_facts: no
   force_handlers: True
   tasks:
-  - name: update packages
+  - name: Update packages
     shell: apt update
     
   - name: Ensure unzip is installed
@@ -25,7 +25,11 @@
   - name: Remove all kernels other than the active kernel # This might install unsigned versions of some kernels
     shell: |
       kernel=$(uname -r)
-      dpkg -l | grep -i 'linux-image\|linux-headers' | grep -v $kernel | awk '{print $2}' | xargs apt purge --auto-remove -y
+      dpkg -l | grep 'linux-image\|linux-headers' | grep -v $kernel | awk '{print $2}' | xargs apt purge --auto-remove -y
+    ignore_errors: yes
+
+  - name: Remove active kernel boot files
+    shell: rm -f /boot/*
     ignore_errors: yes
 
   - block:
@@ -41,11 +45,8 @@
     
   - name: Configure new kernel boot files
     shell: |
-      kernel=$(dpkg -l | grep -E linux-image-5.4.*-generic | awk '{print $2}' | sed 's/linux-image-//')
+      kernel=$(dpkg -l | grep -E 'linux\-image\-(5\.4|4\.15).*\-generic' | awk '{print $2}' | sed 's/linux-image-//')
       update-initramfs -u -k $kernel
-
-  - name: Remove AWS kernel boot files
-    shell: cd /boot && rm -f *aws
    
   - name: Update grub entries
     shell: |

--- a/ansible/aws/aws_env_setup_ubuntu_20.yaml
+++ b/ansible/aws/aws_env_setup_ubuntu_20.yaml
@@ -6,7 +6,7 @@
   gather_facts: no
   force_handlers: True
   tasks:
-  - name: update packages
+  - name: Update packages
     shell: apt update
 
   - name: Ensure unzip is installed
@@ -25,7 +25,11 @@
   - name: Remove all kernels other than the active kernel # This might install unsigned versions of some kernels
     shell: |
       kernel=$(uname -r)
-      dpkg -l | grep -i 'linux-image\|linux-headers' | grep -v $kernel | awk '{print $2}' | xargs apt purge --auto-remove -y
+      dpkg -l | grep 'linux-image\|linux-headers' | grep -v $kernel | awk '{print $2}' | xargs apt purge --auto-remove -y
+    ignore_errors: yes
+
+  - name: Remove active kernel boot files
+    shell: rm -f /boot/*
     ignore_errors: yes
 
   - block:
@@ -41,11 +45,8 @@
     
   - name: Configure new kernel boot files
     shell: |
-      kernel=$(dpkg -l | grep -E linux-image-5.4.*-generic | awk '{print $2}' | sed 's/linux-image-//')
+      kernel=$(dpkg -l | grep -E 'linux\-image\-5\.4.*\-generic' | awk '{print $2}' | sed 's/linux-image-//')
       update-initramfs -u -k $kernel
-
-  - name: Remove AWS kernel boot files
-    shell: cd /boot && rm -f *aws
 
   - name: Remove EFI entries
     shell: mv /boot/efi/boot/grub/grub.cfg /boot/efi/boot/grub/grub.cfg.bak


### PR DESCRIPTION
AWS needs specific generic kernels for successful migration.
Follow up to #218 which was closed because of some upstream conflicts.
resolves #197 