### PR TITLE
fix: shell set in the wrong image in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:18.14.2 AS stage
 
-SHELL ["/bin/bash", "-c"]
-
 WORKDIR /app
 
 COPY ./UI .
@@ -12,6 +10,8 @@ RUN npm install
 RUN npm run build
 
 FROM ubuntu:18.04
+
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /app
 


### PR DESCRIPTION
Shell should be set in ubuntu image instead of node.